### PR TITLE
added scrollToSlide method

### DIFF
--- a/src/components/Carousel/Carousel.interface.ts
+++ b/src/components/Carousel/Carousel.interface.ts
@@ -8,7 +8,7 @@ export interface CarouselProps {
   slidesPerPageSettings?: SlidesPerPageSettings
   slideWidth?: number
   onScroll?: () => void
-  afterScroll?: () => void
+  afterScroll?: (index: number) => void
 }
 
 export interface SlidesPerPageSettings {

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -1,11 +1,15 @@
-import React, { useRef, useEffect, Children, useState } from 'react'
+import React, { Children, forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import { CarouselProps } from './Carousel.interface'
 import Slide from '../Slide/index'
 import NavArrow from '../NavArrow/index'
 import { getObserver } from '../../utils/intersectionObserver'
 import { StyledCarousel, StyledSlider, StyledUl } from './Carousel.styled'
 
-export const Carousel: React.FC<CarouselProps> = ({
+export interface CarouselRef {
+  scrollToSlide: Function
+}
+
+export const Carousel = forwardRef<CarouselRef, CarouselProps>(({
   onSlideVisible,
   slidesPerPageSettings,
   slideWidth,
@@ -13,7 +17,7 @@ export const Carousel: React.FC<CarouselProps> = ({
   onScroll,
   afterScroll,
   children,
-}) => {
+}, ref) => {
   const [isScrolling, setIsScrolling] = useState(false)
   const scrollTimeout = useRef<number | null>(null)
   const sliderRef = useRef<HTMLDivElement>(null)
@@ -21,34 +25,116 @@ export const Carousel: React.FC<CarouselProps> = ({
   const arrowPrevRef = useRef<HTMLDivElement>(null)
   const arrowNextRef = useRef<HTMLDivElement>(null)
   const observer = useRef<IntersectionObserver>(null)
+  const lastVisibleSlideIndex = useRef(0)
   const intersectionThreshold = 0.66
   const hideArrowThreshold = 30
   const addNode = (node: HTMLLIElement) => slideRefs.current.push(node)
-  useEffect(() => {
-    if (onSlideVisible) {
-      const intersectionCallback = (entries: IntersectionObserverEntry[]) => {
-        entries.forEach((entry: IntersectionObserverEntry) => {
-          if (entry.intersectionRatio >= intersectionThreshold) {
-            const target = entry.target as HTMLDivElement
-            onSlideVisible && onSlideVisible(Number(target.dataset.indexNumber))
-          }
-        })
-      }
 
-      if (observer.current) observer.current.disconnect()
-      const newObserver = getObserver(
-        observer,
-        intersectionCallback,
-        intersectionThreshold
+  const getSlideWidth = useCallback(() => (sliderRef.current?.firstChild?.firstChild as HTMLUListElement)
+  .clientWidth || 0, [])
+
+  const intersectionCallback = useCallback((entries: IntersectionObserverEntry[]) => {
+    entries.forEach((entry: IntersectionObserverEntry) => {
+      if (entry.intersectionRatio >= intersectionThreshold) {
+        const target = entry.target as HTMLUListElement
+        lastVisibleSlideIndex.current = Number(target.dataset.indexNumber)
+        if (onSlideVisible) {
+          onSlideVisible(lastVisibleSlideIndex.current)
+        }
+      }
+    })
+  }, [])
+
+  const isSliderScrollable = useCallback(() => {
+    if (!sliderRef.current) return false
+
+    const sliderWidth = sliderRef.current.clientWidth
+    const slideWidth = getSlideWidth()
+
+    return slideRefs.current.length * slideWidth > sliderWidth
+  }, [])
+
+  const manualScroll = (direction: 'prev' | 'next') => {
+    const dir = direction === 'prev' ? -1 : 1
+    if (sliderRef.current) {
+      const slideWidth = getSlideWidth()
+      const slidesToScroll = Math.floor(
+        sliderRef.current.clientWidth / slideWidth
       )
-      for (const node of slideRefs.current) {
+      sliderRef.current.scrollBy({
+        top: 0,
+        behavior: 'smooth',
+        left: slidesToScroll * slideWidth * dir,
+      })
+    }
+  }
+
+  const onSliderScroll = () => {
+    scrollTimeout.current && clearTimeout(scrollTimeout.current)
+    scrollTimeout.current = setTimeout(() => {
+      scrollTimeout.current = null
+      setIsScrolling(false)
+      if (afterScroll) {
+        afterScroll(lastVisibleSlideIndex.current)
+      }
+    }, 250)
+    if (!isScrolling) {
+      setIsScrolling(true)
+    }
+  }
+
+  const scrollTo = useCallback((left: number) => {
+    if (!sliderRef.current) return
+
+    sliderRef.current.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+      left,
+    })
+  }, [])
+
+  const scrollToSlide = useCallback((index: number) => {
+    if (!sliderRef.current) return
+
+    const sliderScrollLeft = sliderRef.current.scrollLeft
+    const sliderWidth = sliderRef.current.clientWidth
+    const slideWidth = getSlideWidth()
+    const slideLeft = slideWidth * index
+    
+    // only scroll to the left if target slide is outside of view to the left
+    if (slideLeft < sliderScrollLeft) {
+      scrollTo(slideLeft)
+      return
+    }
+
+    // only scroll to the right if target slide is outside of view to the right
+    if (slideLeft + slideWidth > sliderScrollLeft + sliderWidth) {
+      scrollTo(slideLeft + slideWidth - sliderWidth)
+    }
+  }, [])
+
+  useImperativeHandle(ref, () => ({
+    scrollToSlide,
+  }))
+
+  useEffect(() => {
+    if (observer.current) observer.current.disconnect()
+    const newObserver = getObserver(
+      observer,
+      intersectionCallback,
+      intersectionThreshold
+    )
+    for (const node of slideRefs.current) {
+      if (node) {
         newObserver.observe(node)
       }
-      return () => newObserver.disconnect()
     }
-  }, [slideRefs, arrowNextRef, arrowPrevRef, observer, onSlideVisible])
+    return () => newObserver.disconnect()
+  }, [slideRefs.current.length])
 
   useEffect(() => {
+    if (!isSliderScrollable()) return
+
     if (sliderRef.current && arrowNextRef.current && arrowPrevRef.current) {
       if (isScrolling) {
         if (onScroll) {
@@ -73,36 +159,6 @@ export const Carousel: React.FC<CarouselProps> = ({
       }
     }
   }, [isScrolling])
-
-  const onSliderScroll = () => {
-    scrollTimeout.current && clearTimeout(scrollTimeout.current)
-    scrollTimeout.current = setTimeout(() => {
-      scrollTimeout.current = null
-      setIsScrolling(false)
-      if (afterScroll) {
-        afterScroll()
-      }
-    }, 250)
-    if (!isScrolling) {
-      setIsScrolling(true)
-    }
-  }
-
-  const manualScroll = (direction: 'prev' | 'next') => {
-    const dir = direction === 'prev' ? -1 : 1
-    if (sliderRef.current) {
-      const slideWidth = (sliderRef.current.firstChild as HTMLDivElement)
-        .clientWidth
-      const slidesToScroll = Math.floor(
-        sliderRef.current.clientWidth / slideWidth
-      )
-      sliderRef.current.scrollBy({
-        top: 0,
-        behavior: 'smooth',
-        left: slidesToScroll * slideWidth * dir,
-      })
-    }
-  }
 
   return (
     <StyledCarousel>
@@ -137,7 +193,6 @@ export const Carousel: React.FC<CarouselProps> = ({
       <StyledSlider
         onScroll={onSliderScroll}
         ref={sliderRef}
-        id={'scrollSnapDiv'}
       >
         <StyledUl>
           {Children.map(children, (child: JSX.Element, index: number) => (
@@ -155,4 +210,4 @@ export const Carousel: React.FC<CarouselProps> = ({
       </StyledSlider>
     </StyledCarousel>
   )
-}
+})

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -28,7 +28,10 @@ export const Carousel = forwardRef<CarouselRef, CarouselProps>(({
   const lastVisibleSlideIndex = useRef(0)
   const intersectionThreshold = 0.66
   const hideArrowThreshold = 30
-  const addNode = (node: HTMLLIElement) => slideRefs.current.push(node)
+
+  const addNode = useCallback((node: HTMLLIElement, index: number) => {
+    slideRefs.current[index] = node
+  }, [])
 
   const getSlideWidth = useCallback(() => (sliderRef.current?.firstChild?.firstChild as HTMLUListElement)
   .clientWidth || 0, [])
@@ -201,7 +204,7 @@ export const Carousel = forwardRef<CarouselRef, CarouselProps>(({
               slideIndex={index}
               slidesPerPageSettings={slidesPerPageSettings}
               slideWidth={slideWidth}
-              ref={addNode}
+              ref={(node: HTMLLIElement) => addNode(node, index)}
             >
               {child}
             </Slide>
@@ -211,3 +214,5 @@ export const Carousel = forwardRef<CarouselRef, CarouselProps>(({
     </StyledCarousel>
   )
 })
+
+Carousel.displayName = 'Carousel'


### PR DESCRIPTION
- created reusable function to get slide width `getSlideWidth`
- refactored `onSlideVisible`
- created `isSliderScrollable` method to dynamically check if next/prev arrows should be shown
- now passing last visible slide index to `afterScroll` to be able to determine the last slide that became visible
- added `scrollToSlide` method and made it available on component's `ref`
- removed `scrollSnapDiv` id from component