### PR TITLE
feat: multile refinements

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -61,11 +61,14 @@ const App = () => {
       onClick={() => onClick(direction)}
     />
   )
-  const onScroll = () => {
-    console.log('scrolling')
+  const onSlidesVisibilityChange = () => {
+    console.log('slides visibility changed')
   }
-  const afterScroll = () => {
-    console.log('scrolling finished')
+  const onScrollStart = () => {
+    console.log('scrolling started')
+  }
+  const onScrollEnd = () => {
+    console.log('scrolling ended')
   }
   return (
     <>
@@ -79,8 +82,9 @@ const App = () => {
           onSlideVisible={onSlideVisible}
           renderCustomArrow={renderCustomArrow}
           slidesPerPageSettings={slidesPerPageSettings}
-          onScroll={onScroll}
-          afterScroll={afterScroll}
+          onScrollStart={onScrollStart}
+          onSlidesVisibilityChange={onSlidesVisibilityChange}
+          onScrollEnd={onScrollEnd}
         >
           {items.map((item, index) => renderImgSlide(item, index))}
         </Slider>

--- a/src/components/Carousel/Carousel.interface.ts
+++ b/src/components/Carousel/Carousel.interface.ts
@@ -1,5 +1,5 @@
 export interface CarouselProps {
-  onSlideVisible?: (index: number) => void
+  children: React.ReactNode
   renderCustomArrow?: ({
     direction,
     ref,
@@ -7,9 +7,10 @@ export interface CarouselProps {
   }: CustomArrowProps) => JSX.Element
   slidesPerPageSettings?: SlidesPerPageSettings
   slideWidth?: number
-  onScroll?: () => void
-  afterScroll?: (index: number) => void
-  children: React.ReactNode
+  onScrollStart?: (index: number) => void
+  onScrollEnd?: (index: number) => void
+  onSlidesVisibilityChange?: (index: number) => void
+  onSlideVisible?: (index: number) => void
 }
 
 export interface SlidesPerPageSettings {

--- a/src/utils/intersectionObserver.ts
+++ b/src/utils/intersectionObserver.ts
@@ -1,4 +1,5 @@
 export const getObserver = (
+  root: HTMLDivElement | null = null,
   ref: React.MutableRefObject<IntersectionObserver | null>,
   callback: (entries: IntersectionObserverEntry[]) => void,
   threshold: number
@@ -8,7 +9,7 @@ export const getObserver = (
     return observer
   }
   const newObserver = new IntersectionObserver(callback, {
-    root: null,
+    root,
     rootMargin: '0px',
     threshold: threshold,
   })


### PR DESCRIPTION
breaking changes:
- changed `onScroll` to `onScrollStart` to better reflect the actual function
- changed `afterScroll` to `onScrollEnd`
- changed `intersectionThreshold` from 0.66 to 0.5 to determine that the slide is visible when 50% of it is visible
- changed `IntersectionObserver` `root` to the `slider` instead of `null` so that whether the slide is visible or not is based on it's position on the slider and not the entire viewport

added:
- added `onSlidesVisibilityChange` function fires when the visible slides change and receives the index of the middle visible slide

fixed:
- fixed: `isSliderScrollable` calculation
- fixed: change in `IntersectionObserver`
