### PR TITLE
fix: #8 ensure update of scroll status on changed slide count

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifarl/react-scroll-snap-slider",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/module.js",

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -150,7 +150,7 @@ export const Carousel = forwardRef(({
       }
     }
     return () => newObserver.disconnect()
-  }, [slideRefs.current.length])
+  }, [React.Children.count(children)])
 
   useEffect(() => {
     if (!isScrolling) return
@@ -183,7 +183,7 @@ export const Carousel = forwardRef(({
       arrowNextRef.current.style.display = 'block'
       arrowPrevRef.current.style.display = 'block'
     }
-  }, [slideRefs.current.length, isScrolling])
+  }, [React.Children.count(children), isScrolling])
 
   return (
     <StyledCarousel>


### PR DESCRIPTION
Proposal to fix an issue (https://github.com/lifarl/react-scroll-snap-slider/issues/8) with the slider not reliably updating the scroll status when adding children/slides
