### PR TITLE
feat(carousel): add ScrollIndicatorComponent render prop

### DIFF
--- a/src/components/Carousel/Carousel.interface.ts
+++ b/src/components/Carousel/Carousel.interface.ts
@@ -11,6 +11,11 @@ export interface CarouselProps {
   onScrollEnd?: (index: number) => void
   onSlidesVisibilityChange?: (index: number) => void
   onSlideVisible?: (index: number) => void
+  ScrollIndicatorComponent?: React.FC<{
+    handlePositionLeft?: string
+    handleWidth?: string
+    isSliderScrollable?: boolean
+  }>
 }
 
 export interface SlidesPerPageSettings {

--- a/src/components/Carousel/Carousel.styled.ts
+++ b/src/components/Carousel/Carousel.styled.ts
@@ -4,6 +4,7 @@ export const StyledCarousel = styled.div`
   width: 100%;
   height: 100%;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
 `
 

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -2,11 +2,13 @@ import React, { Children, forwardRef, useCallback, useEffect, useImperativeHandl
 import { CarouselProps } from './Carousel.interface'
 import Slide from '../Slide/index'
 import NavArrow from '../NavArrow/index'
+import ScrollIndicator from '../ScrollIndicator/index'
 import { getObserver } from '../../utils/intersectionObserver'
 import { StyledCarousel, StyledSlider, StyledUl } from './Carousel.styled'
 
 export interface CarouselRef {
   scrollToSlide: Function
+  sliderRef: React.Ref<HTMLDivElement>
 }
 
 export const Carousel = forwardRef(({
@@ -18,9 +20,10 @@ export const Carousel = forwardRef(({
   onSlidesVisibilityChange,
   onSlideVisible,
   children,
+  ScrollIndicatorComponent,
 }: CarouselProps, ref: React.Ref<CarouselRef>) => {
   const [isScrolling, setIsScrolling] = useState(false)
-  const scrollTimeout = useRef<number | null>(null)
+  const scrollTimeout = useRef<NodeJS.Timeout | null>(null)
   const sliderRef = useRef<HTMLDivElement>(null)
   const slideRefs = useRef<HTMLLIElement[]>([])
   const arrowPrevRef = useRef<HTMLDivElement>(null)
@@ -134,6 +137,7 @@ export const Carousel = forwardRef(({
 
   useImperativeHandle(ref, () => ({
     scrollToSlide,
+    sliderRef,
   }))
 
   useEffect(() => {
@@ -233,6 +237,8 @@ export const Carousel = forwardRef(({
           ))}
         </StyledUl>
       </StyledSlider>
+
+      {ScrollIndicatorComponent && <ScrollIndicator ScrollIndicatorComponent={ScrollIndicatorComponent} sliderRef={sliderRef} />}
     </StyledCarousel>
   )
 })

--- a/src/components/ScrollIndicator/index.tsx
+++ b/src/components/ScrollIndicator/index.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+
+import { CarouselProps } from '../Carousel/Carousel.interface'
+
+const ScrollIndicator: React.FC<{ ScrollIndicatorComponent: CarouselProps['ScrollIndicatorComponent'], sliderRef: React.RefObject<HTMLDivElement> }> = ({ ScrollIndicatorComponent, sliderRef }) => {
+  const [handlePositionLeft, setHandlePositionLeft] = React.useState('0%')
+  const [handleWidth, setHandleWidth] = React.useState('0%')
+  const [isSliderScrollable, setIsSliderScrollable] = React.useState(false)
+
+  React.useEffect(() => {
+    const onSliderScroll = async () => {
+      const clientWidth = sliderRef.current?.clientWidth || 0
+      const scrollLeft = sliderRef.current?.scrollLeft || 0
+      const scrollWidth = sliderRef.current?.scrollWidth || 0
+
+      const newHandleWidth = `${100 * (clientWidth / (scrollWidth || 1))}%`
+
+      if (handleWidth !== newHandleWidth) {
+        setHandleWidth(newHandleWidth)
+      }
+
+      setHandlePositionLeft(`${100 * (scrollLeft / (scrollWidth || 1))}%`)
+
+      if (!isSliderScrollable && scrollWidth > clientWidth + 1) {
+        setIsSliderScrollable(true)
+      } else if (isSliderScrollable) {
+        setIsSliderScrollable(false)
+      }
+    }
+
+    sliderRef.current?.addEventListener('scroll', onSliderScroll)
+    onSliderScroll()
+
+    return () => sliderRef.current?.removeEventListener('scroll', onSliderScroll)
+  }, [sliderRef])
+
+  if (!ScrollIndicatorComponent) return null
+
+  return <ScrollIndicatorComponent handlePositionLeft={handlePositionLeft} handleWidth={handleWidth} isSliderScrollable={isSliderScrollable} />
+}
+
+ScrollIndicator.displayName = 'ScrollIndicator'
+
+export default ScrollIndicator


### PR DESCRIPTION
We need to have the scroll indicator in other places like we already have on pdp gallery, but not sure yet if to build it in your component or just expose sliderRef and build it in webmobile-sc,
if in your component one just passes own component that receives (handleWidth: '%', handlePositionLeft: '%', isSliderScrollable: boolean) and decide what to do with those props.

