### PR TITLE
feat(styled): exposed styled components for custom styling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
 import { Carousel } from './components/Carousel/index'
 export const Slider = Carousel
+export { StyledCarousel, StyledSlider, StyledUl } from './components/Carousel/Carousel.styled'
+export { StyledSlide } from './components/Slide/Slide.styled'
+export { StyledNavWrapper, StyledArrow } from './components/NavArrow/NavArrow.styled'


### PR DESCRIPTION
Reasoning is we found ourselves having to do hacky stuff to be able customize the styling of the elements within the slider:

INSTEAD OF THIS:
```
export const ServiceSliderWrapper = styled(ScrollSnapSlider)(
  ({ theme }) => `
  margin-top: ${theme.spacing.base.xs};
  margin-bottom: ${theme.spacing.base.md};
  ul {
    white-space: pre-wrap;
    > li {
      margin: 0px !important;
      padding: ${theme.spacing.base.xs};
      min-width: 80%;
      &:first-child {
        padding-left: 0px;
      }
      @media (max-width: ${theme.breakpoints.xl}px) and (min-width: ${theme.breakpoints.lg}px) {
        min-width: 100%;
      }
      @media (max-width: ${theme.breakpoints.sm}px) {
        min-width: revert;
      }
    }
  }
  > div > div:last-child {
    margin: -1px;
    padding: 1px;
  }
`
)
```

DO THIS:
```
export const ServiceSliderWrapper = styled(ScrollSnapSlider)(
  ({ theme }) => `
  margin-top: ${theme.spacing.base.xs};
  margin-bottom: ${theme.spacing.base.md};
  ${StyledSlider} {
    margin: -1px;
    padding: 1px;
  }
  ${StyledUl} {
    white-space: pre-wrap;
  }
  ${StyledSlide} {
    margin: 0px !important;
    padding: ${theme.spacing.base.xs};
    min-width: 80%;
    &:first-child {
      padding-left: 0px;
    }
    @media (max-width: ${theme.breakpoints.xl}px) and (min-width: ${theme.breakpoints.lg}px) {
      min-width: 100%;
    }
    @media (max-width: ${theme.breakpoints.sm}px) {
      min-width: revert;
    }
  }
`
)
```