### PR TITLE
Avoid layout overflow

### DIFF
--- a/src/components/Carousel/Carousel.styled.ts
+++ b/src/components/Carousel/Carousel.styled.ts
@@ -16,7 +16,7 @@ export const StyledSlider = styled.div`
   scrollbar-width: none;
   scroll-snap-type: x mandatory;
   scroll-behavior: smooth;
-  overflow-x: scroll;
+  overflow-x: hidden;
   width: 100%;
 `
 


### PR DESCRIPTION
Changing the value from scroll to hidden will avoid unnecessary render of other sliders which save GPU consumption please check the following images.

Before
<img width="1930" alt="Before" src="https://user-images.githubusercontent.com/3355748/134877972-9d89053c-9b33-4757-bb41-32c3b4936e7c.png">


After
<img width="1983" alt="After" src="https://user-images.githubusercontent.com/3355748/134877954-6007b6b1-f90a-4d0c-bcb0-1350674a23a6.png">
