### PR TITLE
A11y: Add tabindex to StyledSlider component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifarl/react-scroll-snap-slider",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/module.js",

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -243,7 +243,7 @@ export const Carousel = forwardRef(
           </React.Fragment>
         )}
 
-        <StyledSlider onScroll={onSliderScroll} ref={sliderRef}>
+        <StyledSlider onScroll={onSliderScroll} ref={sliderRef} tabIndex={0}>
           <StyledUl>
             {Children.map(children, (child: JSX.Element, index: number) => (
               <Slide


### PR DESCRIPTION
Adding a tabindex to this container div will allow the browser to focus the slider with keyboard navigation.

Fixes the following accessibility issue: https://dequeuniversity.com/rules/axe/4.2/scrollable-region-focusable?application=axeAPI